### PR TITLE
Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,7 @@ node_modules
 dist
 .git
 *.tsbuildinfo
-.opencode
 tests
+# Exclude .opencode except skills/ (needed by install-skills)
+.opencode/*
+!.opencode/skills

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.git
+*.tsbuildinfo
+.opencode
+tests

--- a/.opencode/skills/git-confluence/SKILL.md
+++ b/.opencode/skills/git-confluence/SKILL.md
@@ -5,7 +5,7 @@ description: Using git-confluence commands to search, read, and update Confluenc
 
 ## Overview
 
-`git-confluence` interacts with Confluence Cloud via its REST API v2.
+`gitj confluence` interacts with Confluence Cloud via its REST API v2.
 Authentication uses git config values with fallback to `jira.*` equivalents:
 
 ```sh
@@ -17,11 +17,11 @@ git config --global confluence.token your-api-token            # falls back to j
 ## Commands
 
 ```
-git-confluence whoami              Show current authenticated user
-git-confluence space list          List all spaces
-git-confluence page search <q>     Search pages (fuzzy title, --exact, or --full-text)
-git-confluence page show <id>      Show page metadata (add --body-format for content)
-git-confluence page update <id>    Update page content (from stdin or --file)
+gitj confluence whoami              Show current authenticated user
+gitj confluence space list          List all spaces
+gitj confluence page search <q>     Search pages (fuzzy title, --exact, or --full-text)
+gitj confluence page show <id>      Show page metadata (add --body-format for content)
+gitj confluence page update <id>    Update page content (from stdin or --file)
 ```
 
 Use `--help` on any command for options.
@@ -41,42 +41,42 @@ Use `--help` on any command for options.
 
 ```sh
 # 1. Find the page
-git-confluence page search "My Page Title"
+gitj confluence page search "My Page Title"
 
 # 2. Read content (outputs raw storage-format XHTML)
-git-confluence page show <id> --body-format storage --body-only > page.html
+gitj confluence page show <id> --body-format storage --body-only > page.html
 
 # 3. Edit page.html as needed (must remain valid storage format)
 
 # 4. Push the update
-git-confluence page update <id> --file page.html --message "Updated content"
+gitj confluence page update <id> --file page.html --message "Updated content"
 ```
 
 Content can also be piped via stdin:
 
 ```sh
-cat page.html | git-confluence page update <id>
+cat page.html | gitj confluence page update <id>
 ```
 
 ## Arbitrary Confluence API Access
 
-For operations not covered by the dedicated commands, use `git-api confluence`:
+For operations not covered by the dedicated commands, use `gitj api confluence`:
 
 ```sh
 # GET (default) -- path is relative to /wiki/api/v2
-git-api confluence /spaces
-git-api confluence /pages/12345
+gitj api confluence /spaces
+gitj api confluence /pages/12345
 
 # POST (auto-promoted when --data is provided)
-git-api confluence /pages -d '{"spaceId":"123","title":"New Page","body":{"representation":"storage","value":"<p>content</p>"},"status":"current"}'
+gitj api confluence /pages -d '{"spaceId":"123","title":"New Page","body":{"representation":"storage","value":"<p>content</p>"},"status":"current"}'
 
 # Paginated listing
-git-api confluence /spaces --paginate
+gitj api confluence /spaces --paginate
 
 # Skip /wiki/api/v2 prefix for v1 API access
-git-api confluence /wiki/rest/api/content/12345 --raw
+gitj api confluence /wiki/rest/api/content/12345 --raw
 ```
 
-`git-api` handles authentication and base URL automatically. It also supports
+`gitj api` handles authentication and base URL automatically. It also supports
 `-v` (status/headers to stderr), and exits with code 1 on HTTP 4xx/5xx.
-Run `git-api -h` for all options.
+Run `gitj api -h` for all options.

--- a/.opencode/skills/git-jira/SKILL.md
+++ b/.opencode/skills/git-jira/SKILL.md
@@ -5,7 +5,7 @@ description: Using git-jira commands to work with Jira issues and branches
 
 ## Overview
 
-`git-jira` interacts with Jira Cloud via its REST API v3. Authentication uses
+`gitj jira` interacts with Jira Cloud via its REST API v3. Authentication uses
 git config values:
 
 ```sh
@@ -17,11 +17,11 @@ git config --global jira.token your-api-token
 ## Commands
 
 ```
-git-jira whoami              Show current Jira user
-git-jira issue list          List your unresolved issues (shortcut: git-jira list)
-git-jira issue show <key>    Show a single issue
-git-jira start <key>         Create a branch from an issue key + summary
-git-bump                     Increment the branch version suffix
+gitj jira whoami              Show current Jira user
+gitj jira issue list          List your unresolved issues (shortcut: gitj jira list)
+gitj jira issue show <key>    Show a single issue
+gitj jira start <key>         Create a branch from an issue key + summary
+gitj bump                     Increment the branch version suffix
 ```
 
 All dedicated commands are **read-only**. Use `--help` on any command for options.
@@ -29,9 +29,9 @@ All dedicated commands are **read-only**. Use `--help` on any command for option
 ## Workflow: Start Working on a Jira Issue
 
 ```sh
-git-jira issue list          # find your unresolved issues
-git-jira start PROJ-123      # creates and checks out a descriptive branch
-git-bump                     # re-branch with incremented suffix if needed
+gitj jira issue list          # find your unresolved issues
+gitj jira start PROJ-123      # creates and checks out a descriptive branch
+gitj bump                     # re-branch with incremented suffix if needed
 ```
 
 The `start` command only creates a local branch -- it does not push or
@@ -40,24 +40,24 @@ transition the Jira issue.
 ## Arbitrary Jira API Access
 
 The dedicated commands are read-only. For write operations (creating issues,
-transitions, comments, etc.), use `git-api jira`:
+transitions, comments, etc.), use `gitj api jira`:
 
 ```sh
 # GET (default) -- path is relative to /rest/api/3
-git-api jira /myself
-git-api jira /issue/PROJ-123
+gitj api jira /myself
+gitj api jira /issue/PROJ-123
 
 # POST (auto-promoted when --data is provided)
-git-api jira /issue -d '{"fields":{"project":{"key":"PROJ"},"summary":"New issue","issuetype":{"name":"Task"}}}'
+gitj api jira /issue -d '{"fields":{"project":{"key":"PROJ"},"summary":"New issue","issuetype":{"name":"Task"}}}'
 
 # Explicit method
-git-api jira /issue/PROJ-123 -X PUT -d '{"fields":{"summary":"Updated title"}}'
-git-api jira /issue/PROJ-123/transitions -d '{"transition":{"id":"31"}}'
+gitj api jira /issue/PROJ-123 -X PUT -d '{"fields":{"summary":"Updated title"}}'
+gitj api jira /issue/PROJ-123/transitions -d '{"transition":{"id":"31"}}'
 
 # Skip /rest/api/3 prefix for full URL control
-git-api jira /rest/api/2/myself --raw
+gitj api jira /rest/api/2/myself --raw
 ```
 
-`git-api` handles authentication and base URL automatically. It also supports
+`gitj api` handles authentication and base URL automatically. It also supports
 `--paginate`, `-v` (status/headers to stderr), and exits with code 1 on HTTP
-4xx/5xx. Run `git-api -h` for all options.
+4xx/5xx. Run `gitj api -h` for all options.

--- a/.opencode/skills/git-lab/SKILL.md
+++ b/.opencode/skills/git-lab/SKILL.md
@@ -5,7 +5,7 @@ description: Using git-lab commands to work with GitLab projects, merge requests
 
 ## Overview
 
-`git-lab` interacts with GitLab via its REST API v4. Authentication uses git
+`gitj lab` interacts with GitLab via its REST API v4. Authentication uses git
 config values:
 
 ```sh
@@ -19,20 +19,20 @@ The token is sent as a `Private-Token` header. User identity is resolved from
 ## Commands
 
 ```
-git-lab whoami                     Show current GitLab user
-git-lab group list                 List groups
-git-lab namespace list             List namespaces
-git-lab project list [--match]     List projects (server + client-side filter)
-git-lab project whereami           Identify project from current git remote
-git-lab project mr list            List MRs for a project/branch (defaults to current)
-git-lab merge active               My open merge requests (across all projects)
-git-lab merge todo                 MRs where I'm assigned as reviewer
-git-lab merge train list           Merge trains for the current project
-git-lab project pipeline list      Recent pipelines (scoped to current user)
-git-lab project pipeline latest    Jobs for latest pipeline on current branch
-git-lab project pipeline jobs      Jobs for a specific pipeline
-git-lab project pipeline log       Download a job's log output (plain text)
-git-bump                           Increment branch version suffix
+gitj lab whoami                     Show current GitLab user
+gitj lab group list                 List groups
+gitj lab namespace list             List namespaces
+gitj lab project list [--match]     List projects (server + client-side filter)
+gitj lab project whereami           Identify project from current git remote
+gitj lab project mr list            List MRs for a project/branch (defaults to current)
+gitj lab merge active               My open merge requests (across all projects)
+gitj lab merge todo                 MRs where I'm assigned as reviewer
+gitj lab merge train list           Merge trains for the current project
+gitj lab project pipeline list      Recent pipelines (scoped to current user)
+gitj lab project pipeline latest    Jobs for latest pipeline on current branch
+gitj lab project pipeline jobs      Jobs for a specific pipeline
+gitj lab project pipeline log       Download a job's log output (plain text)
+gitj bump                           Increment branch version suffix
 ```
 
 All dedicated commands are **read-only**. Use `--help` on any command for
@@ -53,7 +53,7 @@ options and defaults.
 ### Find the MR for the current branch
 
 ```sh
-git-lab project mr list
+gitj lab project mr list
 ```
 
 Defaults to the current directory's project and current branch. Use
@@ -62,41 +62,41 @@ Defaults to the current directory's project and current branch. Use
 ### Debug a CI failure
 
 ```sh
-git-lab project pipeline latest              # see jobs for current branch
-git-lab project pipeline log --job <id>      # download the log
-git-lab project pipeline log --job <id> --tail 200   # last 200 lines
+gitj lab project pipeline latest              # see jobs for current branch
+gitj lab project pipeline log --job <id>      # download the log
+gitj lab project pipeline log --job <id> --tail 200   # last 200 lines
 ```
 
 ### Review merge requests
 
 ```sh
-git-lab merge todo       # MRs needing my review
-git-lab merge active     # my own open MRs
+gitj lab merge todo       # MRs needing my review
+gitj lab merge active     # my own open MRs
 ```
 
 ## Arbitrary GitLab API Access
 
 The dedicated commands are read-only. For write operations (approving MRs,
-posting comments, triggering pipelines, etc.), use `git-api gitlab`:
+posting comments, triggering pipelines, etc.), use `gitj api gitlab`:
 
 ```sh
 # GET (default) -- path is relative to /api/v4
-git-api gitlab /user
-git-api gitlab /projects/123/merge_requests
+gitj api gitlab /user
+gitj api gitlab /projects/123/merge_requests
 
 # POST (auto-promoted when --data is provided)
-git-api gitlab /projects/123/merge_requests/456/notes -d '{"body":"LGTM"}'
+gitj api gitlab /projects/123/merge_requests/456/notes -d '{"body":"LGTM"}'
 
 # Explicit method
-git-api gitlab /projects/123/merge_requests/456/approve -X POST
+gitj api gitlab /projects/123/merge_requests/456/approve -X POST
 
 # Paginated listing
-git-api gitlab /projects --paginate
+gitj api gitlab /projects --paginate
 
 # Skip /api/v4 prefix for full URL control
-git-api gitlab /api/v4/version --raw
+gitj api gitlab /api/v4/version --raw
 ```
 
-`git-api` handles authentication and base URL automatically. It also supports
+`gitj api` handles authentication and base URL automatically. It also supports
 `-v` (status/headers to stderr), and exits with code 1 on HTTP 4xx/5xx.
-Run `git-api -h` for all options.
+Run `gitj api -h` for all options.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,15 @@
 #
 # Usage:
 #   docker run --rm \
-#     -v "$HOME/.gitconfig:/root/.gitconfig:ro" \
+#     --user "$(id -u):$(id -g)" \
+#     -e HOME="$HOME" \
+#     -v "$HOME:$HOME" \
 #     -v "$(pwd):$(pwd)" -w "$(pwd)" \
 #     gitj <command> [args...]
 #
 # Examples:
-#   docker run --rm -v "$HOME/.gitconfig:/root/.gitconfig:ro" -v "$(pwd):$(pwd)" -w "$(pwd)" gitj jira start
-#   docker run --rm -v "$HOME/.gitconfig:/root/.gitconfig:ro" -v "$(pwd):$(pwd)" -w "$(pwd)" gitj lab merge active
+#   docker run --rm --user "$(id -u):$(id -g)" -e HOME="$HOME" -v "$HOME:$HOME" -v "$(pwd):$(pwd)" -w "$(pwd)" gitj jira start
+#   docker run --rm --user "$(id -u):$(id -g)" -e HOME="$HOME" -v "$HOME:$HOME" -v "$(pwd):$(pwd)" -w "$(pwd)" gitj lab merge active
 
 FROM oven/bun:1 AS builder
 
@@ -42,6 +44,9 @@ WORKDIR /app
 COPY --from=builder /build/dist/ dist/
 COPY --from=builder /build/node_modules/ node_modules/
 COPY package.json ./
+
+# Include skill files so install-skills can copy them into projects
+COPY .opencode/skills/ .opencode/skills/
 
 # Symlink all bin entries onto PATH
 RUN mkdir -p /usr/local/bin && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# ya-git-jira Docker image
+# Provides gitj/git-jira/git-lab/git-confluence/git-bump commands
+# without requiring bun installed on the host.
+#
+# Build:
+#   docker build -t gitj .
+#
+# Usage:
+#   docker run --rm \
+#     -v "$HOME/.gitconfig:/root/.gitconfig:ro" \
+#     -v "$(pwd):$(pwd)" -w "$(pwd)" \
+#     gitj <command> [args...]
+#
+# Examples:
+#   docker run --rm -v "$HOME/.gitconfig:/root/.gitconfig:ro" -v "$(pwd):$(pwd)" -w "$(pwd)" gitj jira start
+#   docker run --rm -v "$HOME/.gitconfig:/root/.gitconfig:ro" -v "$(pwd):$(pwd)" -w "$(pwd)" gitj lab merge active
+
+FROM oven/bun:1 AS builder
+
+WORKDIR /build
+
+# Install dependencies first (cache layer)
+COPY package.json bun.lockb ./
+RUN bun install --frozen-lockfile --production --ignore-scripts
+
+# Copy source and build
+COPY build.ts index.ts tsconfig.json ./
+COPY bin/ bin/
+COPY lib/ lib/
+RUN bun run build.ts
+
+# --- Runtime stage ---
+FROM oven/bun:1-slim
+
+# git is required - the tool reads config from git and operates on repos
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy built artifacts and dependencies
+COPY --from=builder /build/dist/ dist/
+COPY --from=builder /build/node_modules/ node_modules/
+COPY package.json ./
+
+# Symlink all bin entries onto PATH
+RUN mkdir -p /usr/local/bin && \
+    for f in dist/bin/*.js; do \
+        name=$(basename "$f" .js); \
+        ln -s /app/"$f" /usr/local/bin/"$name"; \
+    done
+
+ENTRYPOINT ["gitj"]

--- a/README.md
+++ b/README.md
@@ -5,31 +5,38 @@ executable that `git` discovers automatically (e.g. `git jira start`, `git lab
 merge active`, `git confluence page search`). A unified `gitj` wrapper is also
 provided.
 
-## Requirements
-
-[Bun](https://bun.sh) (not Node.js) — or Docker if you prefer not to install Bun.
-
-```
-curl -fsSL https://bun.sh/install | bash
-```
-
 ## Install
 
-```
-npm install -g ya-git-jira   # or bun / yarn / pnpm
-```
+There are three ways to install. Options 1 and 2 require
+[Bun](https://bun.sh). Option 3 requires only Docker.
 
-### Docker (alternative)
-
-No bun required — just Docker:
+### Option 1: npm install (requires Bun)
 
 ```
+curl -fsSL https://bun.sh/install | bash   # install Bun first
+npm install -g ya-git-jira                  # or bun / yarn / pnpm
+```
+
+### Option 2: Clone and build (requires Bun)
+
+```
+git clone https://github.com/jimlloyd/ya-git-jira.git
+cd ya-git-jira
+bun install
+bun link
+```
+
+### Option 3: Clone and Docker (no Bun needed)
+
+```
+git clone https://github.com/jimlloyd/ya-git-jira.git
+cd ya-git-jira
 ./install-docker-gitj.sh
 ```
 
-This builds the Docker image and installs a `gitj` wrapper script into a bin
-directory on your PATH (e.g. `~/.local/bin`). Then use it like the native
-install: `gitj jira start BUG-42`.
+This builds a Docker image and installs a `gitj` wrapper script into a bin
+directory on your PATH (e.g. `~/.local/bin`). The wrapper transparently runs
+commands inside Docker, so usage is identical to a native install.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ provided.
 
 ## Requirements
 
-[Bun](https://bun.sh) (not Node.js):
+[Bun](https://bun.sh) (not Node.js) — or Docker if you prefer not to install Bun.
 
 ```
 curl -fsSL https://bun.sh/install | bash
@@ -18,6 +18,31 @@ curl -fsSL https://bun.sh/install | bash
 ```
 npm install -g ya-git-jira   # or bun / yarn / pnpm
 ```
+
+### Docker (alternative)
+
+Build the image once:
+
+```
+docker build -t gitj .
+```
+
+Then run any command by mounting your git config and current directory:
+
+```
+docker run --rm \
+  -v "$HOME/.gitconfig:/root/.gitconfig:ro" \
+  -v "$(pwd):$(pwd)" -w "$(pwd)" \
+  gitj <command> [args...]
+```
+
+For convenience, add a shell alias:
+
+```bash
+alias gitj='docker run --rm -v "$HOME/.gitconfig:/root/.gitconfig:ro" -v "$(pwd):$(pwd)" -w "$(pwd)" gitj'
+```
+
+Then use it exactly like the native install: `gitj jira start BUG-42`.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -154,16 +154,16 @@ one-off queries and scripting.
 ### gitj install-skills
 
 ```
-gitj install-skills opencode       # symlinks to ~/.config/opencode/skills/
-gitj install-skills copilot        # symlinks to ~/.copilot/skills/
-gitj install-skills claude         # symlinks to .claude/skills/ (project-level)
-gitj install-skills opencode --copy   # copy instead of symlink
+gitj install-skills opencode       # copies to .opencode/skills/
+gitj install-skills copilot        # copies to .github/skills/
+gitj install-skills claude         # copies to .claude/skills/
 gitj install-skills opencode --force  # overwrite existing directories
 ```
 
-Installs AI agent skill files (`git-jira`, `git-lab`, `git-confluence`) so that
-coding assistants (OpenCode, GitHub Copilot, Claude Code) know how to use these
-tools.
+Skills are installed into the current project directory. Run this from your
+project root so that your AI coding assistant discovers the skill files. When
+running via Docker, files are always copied (symlinks would point into the
+container).
 
 ## AI agent skills
 

--- a/README.md
+++ b/README.md
@@ -21,28 +21,15 @@ npm install -g ya-git-jira   # or bun / yarn / pnpm
 
 ### Docker (alternative)
 
-Build the image once:
+No bun required — just Docker:
 
 ```
-docker build -t gitj .
+./install-docker-gitj.sh
 ```
 
-Then run any command by mounting your git config and current directory:
-
-```
-docker run --rm \
-  -v "$HOME/.gitconfig:/root/.gitconfig:ro" \
-  -v "$(pwd):$(pwd)" -w "$(pwd)" \
-  gitj <command> [args...]
-```
-
-For convenience, add a shell alias:
-
-```bash
-alias gitj='docker run --rm -v "$HOME/.gitconfig:/root/.gitconfig:ro" -v "$(pwd):$(pwd)" -w "$(pwd)" gitj'
-```
-
-Then use it exactly like the native install: `gitj jira start BUG-42`.
+This builds the Docker image and installs a `gitj` wrapper script into a bin
+directory on your PATH (e.g. `~/.local/bin`). Then use it like the native
+install: `gitj jira start BUG-42`.
 
 ## Configuration
 

--- a/bin/gitj-install-skills.ts
+++ b/bin/gitj-install-skills.ts
@@ -6,7 +6,6 @@ import { findPackageJson } from '../lib/package'
 import { isMain } from '../lib/is_main'
 import fs from 'node:fs'
 import path from 'node:path'
-import os from 'node:os'
 
 const version = await getPackageVersion()
 
@@ -29,14 +28,14 @@ function getSkillsSourceDir(): string {
 }
 
 function getTargetDir(framework: Framework): string {
-    const home = os.homedir()
+    const cwd = process.cwd()
     switch (framework) {
         case 'opencode':
-            return path.join(home, '.config', 'opencode', 'skills')
+            return path.join(cwd, '.opencode', 'skills')
         case 'copilot':
-            return path.join(home, '.copilot', 'skills')
+            return path.join(cwd, '.github', 'skills')
         case 'claude':
-            return path.join(process.cwd(), '.claude', 'skills')
+            return path.join(cwd, '.claude', 'skills')
     }
 }
 
@@ -101,7 +100,7 @@ export function create(): Command {
         .name('install-skills')
         .description('Install AI agent skills for a coding framework')
         .argument('<framework>', `framework to install for (${frameworks.join(', ')})`)
-        .option('--copy', 'copy files instead of creating symlinks')
+        .option('--copy', 'copy files instead of creating symlinks (automatic in Docker)')
         .option('--force', 'overwrite existing skill directories')
         .action(async (framework: string, options: { copy?: boolean; force?: boolean }) => {
             if (!frameworks.includes(framework as Framework)) {
@@ -110,10 +109,16 @@ export function create(): Command {
                 process.exit(1)
             }
 
+            // When running in Docker, source files live inside the container
+            // so symlinks would be broken on the host. Force copy mode.
+            const sourceDir = getSkillsSourceDir()
+            const inDocker = sourceDir.startsWith('/app/')
+            const copy = !!(options.copy || inDocker)
+
             if (options.force) {
-                forceInstallSkills(framework as Framework, !!options.copy)
+                forceInstallSkills(framework as Framework, copy)
             } else {
-                installSkills(framework as Framework, !!options.copy)
+                installSkills(framework as Framework, copy)
             }
         })
     return program

--- a/install-docker-gitj.sh
+++ b/install-docker-gitj.sh
@@ -59,7 +59,9 @@ WRAPPER="$BIN_DIR/$WRAPPER_NAME"
 cat > "$WRAPPER" << 'SCRIPT'
 #!/usr/bin/env bash
 exec docker run --rm \
-  -v "$HOME/.gitconfig:/root/.gitconfig:ro" \
+  --user "$(id -u):$(id -g)" \
+  -e HOME="$HOME" \
+  -v "$HOME:$HOME" \
   -v "$(pwd):$(pwd)" -w "$(pwd)" \
   gitj "$@"
 SCRIPT

--- a/install-docker-gitj.sh
+++ b/install-docker-gitj.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="gitj"
+WRAPPER_NAME="gitj"
+
+# --- Find a writable bin directory on PATH under $HOME ---
+
+find_bin_dir() {
+    # Prefer ~/.local/bin if it exists and is on PATH
+    if [ -d "$HOME/.local/bin" ]; then
+        case ":$PATH:" in
+            *":$HOME/.local/bin:"*) echo "$HOME/.local/bin"; return 0 ;;
+        esac
+    fi
+
+    # Search PATH for any directory under $HOME
+    IFS=: read -ra path_dirs <<< "$PATH"
+    for dir in "${path_dirs[@]}"; do
+        case "$dir" in
+            "$HOME"/*)
+                if [ -d "$dir" ] && [ -w "$dir" ]; then
+                    echo "$dir"
+                    return 0
+                fi
+                ;;
+        esac
+    done
+
+    # Fall back to creating ~/.local/bin
+    echo ""
+    return 1
+}
+
+# --- Main ---
+
+echo "Building Docker image '$IMAGE_NAME'..."
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+docker build -t "$IMAGE_NAME" "$SCRIPT_DIR"
+echo ""
+
+BIN_DIR=$(find_bin_dir) || true
+
+if [ -z "$BIN_DIR" ]; then
+    BIN_DIR="$HOME/.local/bin"
+    echo "No bin directory found under \$HOME on your PATH."
+    echo "Creating $BIN_DIR ..."
+    mkdir -p "$BIN_DIR"
+    echo ""
+    echo "WARNING: $BIN_DIR is not on your PATH."
+    echo "Add this to your shell profile (~/.bashrc, ~/.zshrc, etc.):"
+    echo ""
+    echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+    echo ""
+fi
+
+WRAPPER="$BIN_DIR/$WRAPPER_NAME"
+
+cat > "$WRAPPER" << 'SCRIPT'
+#!/usr/bin/env bash
+exec docker run --rm \
+  -v "$HOME/.gitconfig:/root/.gitconfig:ro" \
+  -v "$(pwd):$(pwd)" -w "$(pwd)" \
+  gitj "$@"
+SCRIPT
+
+chmod +x "$WRAPPER"
+
+echo "Installed $WRAPPER"
+echo ""
+echo "Usage:"
+echo "  gitj --version"
+echo "  gitj jira start BUG-42"
+echo "  gitj lab merge active"
+echo "  gitj --help-all"


### PR DESCRIPTION
This pull request introduces Docker-based installation and usage for the `ya-git-jira` toolset, allowing users to run the suite (`gitj`, `git-jira`, `git-lab`, `git-confluence`, `git-bump`) without requiring Bun on the host system. It also updates documentation and skill files to reflect a unified `gitj` command, and improves skill installation behavior for AI coding assistants.

**Key changes:**

**Docker support and installation:**
- Added a `Dockerfile` to build a Docker image containing all CLI tools and their dependencies, with entrypoint set to `gitj`. This enables running commands in a containerized environment without Bun installed on the host.
- Added `install-docker-gitj.sh` script to build the Docker image and install a `gitj` wrapper script into a user-writable bin directory, making Dockerized usage seamless and matching native CLI usage.
- Updated `.dockerignore` to exclude unnecessary files from the Docker build context, optimizing image size and build time.

**Documentation updates:**
- Updated the `README.md` with new installation instructions, including Docker-based installation as an option not requiring Bun, and clarified skill installation to use file copies rather than symlinks when running in Docker. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R40) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L145-R173)
- Revised skill documentation (`SKILL.md` files for Confluence, Jira, and GitLab) to standardize on the `gitj` command prefix, replacing legacy `git-jira`, `git-lab`, and `git-confluence` commands, and updated examples for API usage. [[1]](diffhunk://#diff-91ef94f62b1e44d04dcff482ebf1fea9c5bea917e8a9b699c64fb58c4b8fc9e6L8-R8) [[2]](diffhunk://#diff-91ef94f62b1e44d04dcff482ebf1fea9c5bea917e8a9b699c64fb58c4b8fc9e6L20-R24) [[3]](diffhunk://#diff-91ef94f62b1e44d04dcff482ebf1fea9c5bea917e8a9b699c64fb58c4b8fc9e6L44-R82) [[4]](diffhunk://#diff-6ec53ebcdd358256fefe3651e4ee0f81fd832e23dd9ff26d6479bc80f1cb6f66L8-R8) [[5]](diffhunk://#diff-6ec53ebcdd358256fefe3651e4ee0f81fd832e23dd9ff26d6479bc80f1cb6f66L20-R34) [[6]](diffhunk://#diff-6ec53ebcdd358256fefe3651e4ee0f81fd832e23dd9ff26d6479bc80f1cb6f66L43-R63) [[7]](diffhunk://#diff-3256baaedca0642afee88701d5cc8f0bcf6fbb845136ea62bc22bff7e7ab4336L8-R8) [[8]](diffhunk://#diff-3256baaedca0642afee88701d5cc8f0bcf6fbb845136ea62bc22bff7e7ab4336L22-R35) [[9]](diffhunk://#diff-3256baaedca0642afee88701d5cc8f0bcf6fbb845136ea62bc22bff7e7ab4336L56-R56) [[10]](diffhunk://#diff-3256baaedca0642afee88701d5cc8f0bcf6fbb845136ea62bc22bff7e7ab4336L65-R102)

**Skill installation improvements:**
- Changed `gitj install-skills` to always copy skill files into project directories (rather than symlinking), ensuring compatibility with Docker-based installs and various AI coding assistants.

These updates make the toolset more accessible to users without Bun, unify command usage, and improve integration with AI development tools.