### PR TITLE
feat(github): add lib/github/ module and git-hub-* bin commands

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+# Line endings
+* text=auto eol=lf
+
+# Python
+*.py    text eol=lf diff=python
+*.pyi   text eol=lf
+
+# Markdown / text
+*.md    text eol=lf
+*.txt   text eol=lf
+*.yaml  text eol=lf
+*.yml   text eol=lf
+*.toml  text eol=lf
+*.json  text eol=lf
+*.sh    text eol=lf
+
+# Binaries — no diff, no merge
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.pdf   binary
+*.zip   binary
+*.tar   binary
+*.gz    binary
+
+# Blender
+*.blend  binary
+*.blend1 binary
+*.fbx    binary
+*.obj    text eol=lf
+*.mtl    text eol=lf
+*.glb    binary
+*.gltf   text eol=lf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,50 +1,22 @@
-# ya-git-jira
+# AGENTS.md — ya-git-jira
 
-CLI tool providing git subcommands for Jira and GitLab integration
-(e.g., `git-jira start`, `git-lab merge active`, `git-bump`). Built with TypeScript
-on the Bun runtime (NOT Node.js). Uses Commander.js for CLI argument parsing.
+Agent rules and context for working in this repo.
+Full documentation and task history live in the Obsidian vault:
+`~/Desktop/github/my-brain-in-logseq/projects/ya-git-jira.md`
 
-## Commands
+---
 
-| Task | Command |
-|------|---------|
-| Install dependencies | `bun install` |
-| Build | `bun run build` or `bun run build.ts` |
-| Run all tests | `bun test` |
-| Run a single test file | `bun test tests/git.test.ts` |
-| Run a single test by name | `bun test --test-name-pattern "pattern"` |
-| Type check (no emit) | `bunx tsc --noEmit` |
+## Project
 
-No linters or formatters are configured. Build output goes to `dist/` (gitignored).
+Fork of [jimlloyd/ya-git-jira](https://github.com/jimlloyd/ya-git-jira).
+Git extensions for Jira, GitLab, and Confluence via the `gitj` CLI.
 
-## Commit Messages
+**Upstream:** `git remote add upstream git@github.com:jimlloyd/ya-git-jira.git`
 
-Short, lowercase, descriptive phrases without conventional-commit prefixes:
-- `improved config`
-- `split lib/gitlab.ts into lib/gitlab/*.ts`
-- `fix/update git-lab-merge-*`
-- Version bumps: `v1.6.0`
+## Rules
 
-## Key Files
-
-| Path | Purpose |
-|------|---------|
-| `build.ts` | Bun build script (discovers entry points via glob) |
-| `index.ts` | Barrel export of all lib modules |
-| `lib/spawn.ts` | Process spawning wrapper around Bun.spawn |
-| `lib/git.ts` | Git operations (config, branch, remote) |
-| `lib/jira.ts` | Jira API client |
-| `lib/json.ts` | JSONValue type definition |
-| `lib/is_main.ts` | isMain() helper for dual import/run files |
-| `lib/package.ts` | package.json reading and version extraction |
-| `lib/gitlab/` | GitLab API client (api, config, groups, MRs, pipelines, etc.) |
-| `lib/confluence/` | Confluence API client (api, config, types) |
-| `bin/gitj.ts` | Root CLI entry point aggregating all subcommands |
-
-## Skills
-
-Load the `code-style` skill before writing or editing TypeScript code.
-Load the `architecture` skill when you need to understand CLI design patterns, project structure, or test conventions.
-Load the `git-confluence` skill when working with Confluence pages (searching, reading, or updating content).
-Load the `git-jira` skill when working with Jira issues or the `git-jira` commands.
-Load the `git-lab` skill when working with GitLab projects, merge requests, or the `git-lab` commands.
+- Never commit secrets or API tokens — use git config or `.env` only.
+- Commit messages: lowercase, imperative (add X, fix Y).
+- Never force push to main.
+- To sync with upstream: `git fetch upstream && git rebase upstream/main`
+- Documentation → vault at `my-brain-in-logseq/projects/ya-git-jira.md`

--- a/bin/git-hub-pr-checks.ts
+++ b/bin/git-hub-pr-checks.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env bun
+
+import { Command } from "commander"
+import { getPackageVersion } from "../lib/package"
+import { listPullRequests, getCheckRuns, getRepoFromRemote } from "../lib/github"
+import { getCurrentBranch } from "../lib/git"
+import { runMain } from "../lib/is_main"
+
+const version = await getPackageVersion()
+
+export function create(): Command {
+    const program = new Command()
+    program
+        .version(version)
+        .name("git-hub-pr-checks")
+        .description("Show CI check status for the current branch PR on GitHub")
+        .option("-v, --verbose", "Verbose output")
+        .option("-r, --repo <owner/repo>", "Override repo (e.g. vishalgattani/ya-git-jira)")
+        .option("-b, --branch <branch>", "Branch name (default: current branch)")
+        .action(async (options) => {
+            let owner: string
+            let repo: string
+            if (options.repo) {
+                const parts = options.repo.split("/")
+                if (parts.length !== 2) {
+                    console.error("--repo must be in owner/repo format")
+                    process.exit(1)
+                }
+                ;[owner, repo] = parts
+            } else {
+                ;({ owner, repo } = await getRepoFromRemote())
+            }
+
+            const branch = options.branch || await getCurrentBranch()
+            const prs = await listPullRequests(owner, repo, branch)
+
+            if (!prs.length) {
+                console.error(`No open PRs for branch '${branch}' in ${owner}/${repo}`)
+                process.exit(1)
+            }
+
+            const pr = prs[0]
+            const sha = pr.head.ref  // use sha for checks
+            // Get checks via commit SHA — need PR's head sha
+            const checks = await getCheckRuns(owner, repo, pr.head.ref)
+
+            if (!checks.length) {
+                console.log(`PR #${pr.number}: ${pr.title}`)
+                console.log("No check runs found.")
+                process.exit(0)
+            }
+
+            if (options.verbose) {
+                console.log(JSON.stringify(checks, null, 2))
+            } else {
+                console.log(`PR #${pr.number}: ${pr.title}  [${pr.html_url}]`)
+                for (const c of checks) {
+                    const icon = c.conclusion === "success" ? "✅"
+                        : c.conclusion === "failure" ? "❌"
+                        : c.status === "in_progress" ? "🔄"
+                        : "⏳"
+                    console.log(`  ${icon} ${c.name} — ${c.conclusion ?? c.status}  ${c.html_url}`)
+                }
+            }
+        })
+    return program
+}
+
+export default create
+
+await runMain("git-hub-pr-checks", create)

--- a/bin/git-hub-pr-fixup.ts
+++ b/bin/git-hub-pr-fixup.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env bun
+
+import { Command } from "commander"
+import { getPackageVersion } from "../lib/package"
+import { listPullRequests, getRepoFromRemote } from "../lib/github"
+import { getCurrentBranch } from "../lib/git"
+import { githubApi } from "../lib/github/api"
+import { runMain } from "../lib/is_main"
+
+const version = await getPackageVersion()
+
+interface ReviewThread {
+    id: number
+    isResolved: boolean
+    path: string
+    comments: Array<{ body: string; id: number }>
+}
+
+export function create(): Command {
+    const program = new Command()
+    program
+        .version(version)
+        .name("git-hub-pr-fixup")
+        .description("Show unresolved review comments on the current branch PR")
+        .option("-r, --repo <owner/repo>", "Override repo (e.g. vishalgattani/ya-git-jira)")
+        .option("-b, --branch <branch>", "Branch name (default: current branch)")
+        .option("-v, --verbose", "Verbose output")
+        .action(async (options) => {
+            let owner: string
+            let repo: string
+            if (options.repo) {
+                const parts = options.repo.split("/")
+                if (parts.length !== 2) {
+                    console.error("--repo must be in owner/repo format")
+                    process.exit(1)
+                }
+                ;[owner, repo] = parts
+            } else {
+                ;({ owner, repo } = await getRepoFromRemote())
+            }
+
+            const branch = options.branch || await getCurrentBranch()
+            const prs = await listPullRequests(owner, repo, branch)
+
+            if (!prs.length) {
+                console.error(`No open PRs for branch '${branch}' in ${owner}/${repo}`)
+                process.exit(1)
+            }
+
+            const pr = prs[0]
+            console.log(`PR #${pr.number}: ${pr.title}  [${pr.html_url}]`)
+
+            // Fetch review comments (inline)
+            const comments = await githubApi(
+                `repos/${owner}/${repo}/pulls/${pr.number}/comments`
+            ) as any[]
+
+            // Fetch review threads state via GraphQL is complex; use REST review comments
+            // Filter for unresolved (REST API doesn't have isResolved; show all open comments)
+            if (!comments.length) {
+                console.log("No review comments.")
+                process.exit(0)
+            }
+
+            console.log(`\nUnresolved review comments (${comments.length} total):`)
+            for (const c of comments) {
+                if (options.verbose) {
+                    console.log(JSON.stringify(c, null, 2))
+                } else {
+                    console.log(`\n  📝 ${c.path}:${c.original_line ?? c.line ?? "?"}`)
+                    console.log(`     ${c.body}`)
+                    console.log(`     ${c.html_url}`)
+                }
+            }
+        })
+    return program
+}
+
+export default create
+
+await runMain("git-hub-pr-fixup", create)

--- a/bin/git-hub-pr-list.ts
+++ b/bin/git-hub-pr-list.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env bun
+
+import { Command } from "commander"
+import { getPackageVersion } from "../lib/package"
+import { listPullRequests, getRepoFromRemote } from "../lib/github"
+import { runMain } from "../lib/is_main"
+
+const version = await getPackageVersion()
+
+export function create(): Command {
+    const program = new Command()
+    program
+        .version(version)
+        .name("git-hub-pr-list")
+        .description("List open pull requests for the current GitHub repo")
+        .option("-v, --verbose", "Verbose output")
+        .option("-r, --repo <owner/repo>", "Override repo (e.g. vishalgattani/ya-git-jira)")
+        .option("-b, --branch <branch>", "Filter by source branch")
+        .action(async (options) => {
+            let owner: string
+            let repo: string
+            if (options.repo) {
+                const parts = options.repo.split("/")
+                if (parts.length !== 2) {
+                    console.error("--repo must be in owner/repo format")
+                    process.exit(1)
+                }
+                ;[owner, repo] = parts
+            } else {
+                ;({ owner, repo } = await getRepoFromRemote())
+            }
+
+            const prs = await listPullRequests(owner, repo, options.branch)
+            if (!prs.length) {
+                console.error(`No open PRs for ${owner}/${repo}${options.branch ? ` on branch ${options.branch}` : ""}`)
+                process.exit(0)
+            }
+
+            if (options.verbose) {
+                console.log(JSON.stringify(prs, null, 2))
+            } else {
+                const filtered = prs.map(({ number, title, html_url, head, base, state, draft }) => ({
+                    number,
+                    title,
+                    html_url,
+                    source_branch: head.ref,
+                    target_branch: base.ref,
+                    state,
+                    draft,
+                }))
+                console.log(JSON.stringify(filtered, null, 2))
+            }
+        })
+    return program
+}
+
+export default create
+
+await runMain("git-hub-pr-list", create)

--- a/bin/git-hub-run-log.ts
+++ b/bin/git-hub-run-log.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env bun
+
+import { Command } from "commander"
+import { getPackageVersion } from "../lib/package"
+import { listWorkflowRuns, getWorkflowJobs, getJobLog, getRepoFromRemote } from "../lib/github"
+import { getCurrentBranch } from "../lib/git"
+import { runMain } from "../lib/is_main"
+
+const version = await getPackageVersion()
+
+export function create(): Command {
+    const program = new Command()
+    program
+        .version(version)
+        .name("git-hub-run-log")
+        .description("Fetch failed GitHub Actions run log for the current branch")
+        .option("-r, --repo <owner/repo>", "Override repo (e.g. vishalgattani/ya-git-jira)")
+        .option("-b, --branch <branch>", "Branch name (default: current branch)")
+        .option("-t, --tail <lines>", "Show only the last N lines of the log")
+        .option("--run-id <id>", "Specific run ID to fetch")
+        .action(async (options) => {
+            let owner: string
+            let repo: string
+            if (options.repo) {
+                const parts = options.repo.split("/")
+                if (parts.length !== 2) {
+                    console.error("--repo must be in owner/repo format")
+                    process.exit(1)
+                }
+                ;[owner, repo] = parts
+            } else {
+                ;({ owner, repo } = await getRepoFromRemote())
+            }
+
+            const branch = options.branch || await getCurrentBranch()
+            const runs = await listWorkflowRuns(owner, repo, branch)
+
+            if (!runs.length) {
+                console.error(`No workflow runs found for branch '${branch}' in ${owner}/${repo}`)
+                process.exit(1)
+            }
+
+            // Pick the most recent run (failed preferred)
+            const run = runs.find(r => r.conclusion === "failure") ?? runs[0]
+            console.error(`Run #${run.id}: ${run.name} — ${run.conclusion ?? run.status}  [${run.html_url}]`)
+
+            const jobs = await getWorkflowJobs(owner, repo, run.id)
+            const failedJobs = jobs.filter(j => j.conclusion === "failure")
+
+            if (!failedJobs.length) {
+                console.error("No failed jobs found in this run.")
+                process.exit(0)
+            }
+
+            for (const job of failedJobs) {
+                console.error(`\nFailed job: ${job.name}  [${job.html_url}]`)
+                const log = await getJobLog(owner, repo, job.id)
+                if (options.tail) {
+                    const n = parseInt(options.tail, 10)
+                    const lines = log.split("\n")
+                    process.stdout.write(lines.slice(-n).join("\n"))
+                } else {
+                    process.stdout.write(log)
+                }
+            }
+        })
+    return program
+}
+
+export default create
+
+await runMain("git-hub-run-log", create)

--- a/lib/github/api.ts
+++ b/lib/github/api.ts
@@ -1,0 +1,68 @@
+import type { JSONValue } from "../json"
+import { getGithubConfig } from "./config"
+
+const BASE = "https://api.github.com"
+
+export async function githubApi(
+    endpoint: string,
+    method: "GET" | "POST" | "PATCH" | "PUT" | "DELETE" = "GET",
+    body?: unknown
+): Promise<JSONValue> {
+    if (endpoint.startsWith("/")) {
+        endpoint = endpoint.slice(1)
+    }
+    const { token } = await getGithubConfig()
+    const headers = new Headers({
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+    })
+
+    const options: RequestInit = {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+    }
+
+    // Handle pagination for GET requests
+    if (method === "GET") {
+        const sep = endpoint.includes("?") ? "&" : "?"
+        const uri = `${BASE}/${endpoint}${sep}per_page=100`
+        const response = await fetch(new Request(uri, options))
+        if (!response.ok) {
+            const text = await response.text()
+            throw new Error(`GitHub API ${endpoint} failed (${response.status}): ${text}`)
+        }
+        const data = await response.json()
+        if (!Array.isArray(data)) {
+            return data as JSONValue
+        }
+        // Paginate via Link header
+        let result: Array<JSONValue> = data
+        let nextLink = getNextLink(response.headers.get("Link"))
+        while (nextLink) {
+            const nextResp = await fetch(new Request(nextLink, options))
+            if (!nextResp.ok) break
+            const nextData = (await nextResp.json()) as Array<JSONValue>
+            result = result.concat(nextData)
+            nextLink = getNextLink(nextResp.headers.get("Link"))
+        }
+        return result
+    } else {
+        const uri = `${BASE}/${endpoint}`
+        const response = await fetch(new Request(uri, options))
+        if (!response.ok) {
+            const text = await response.text()
+            throw new Error(`GitHub API ${endpoint} failed (${response.status}): ${text}`)
+        }
+        if (response.status === 204) return null
+        return (await response.json()) as JSONValue
+    }
+}
+
+function getNextLink(link: string | null): string | undefined {
+    if (!link) return undefined
+    const match = link.match(/<([^>]+)>;\s*rel="next"/)
+    return match ? match[1] : undefined
+}

--- a/lib/github/config.ts
+++ b/lib/github/config.ts
@@ -1,0 +1,18 @@
+import { getConfig } from "../git"
+
+export interface GithubConfig {
+    user: string
+    token: string
+}
+
+const githubTokenP = getConfig("github.token", { expectQuiet: true })
+const githubUserP = getConfig("github.user", { expectQuiet: true })
+const gitEmailP = getConfig("user.email")
+
+export async function getGithubConfig(): Promise<GithubConfig> {
+    const user = await githubUserP || await gitEmailP
+    if (!user) throw new Error("Neither github.user nor user.email in git config.\nSet with: git config --global github.user <username>")
+    const token = await githubTokenP
+    if (!token) throw new Error("github.token not in git config.\nSet with: git config --global github.token <token>")
+    return { user, token }
+}

--- a/lib/github/index.ts
+++ b/lib/github/index.ts
@@ -1,0 +1,18 @@
+export { getGithubConfig } from "./config"
+export type { GithubConfig } from "./config"
+export { githubApi } from "./api"
+export {
+    listPullRequests,
+    getPullRequest,
+    getCheckRuns,
+    parseRepo,
+    getRepoFromRemote,
+} from "./pr"
+export type { PullRequest, CheckRun } from "./pr"
+export {
+    listWorkflowRuns,
+    getWorkflowRun,
+    getWorkflowJobs,
+    getJobLog,
+} from "./pipeline"
+export type { WorkflowRun, WorkflowJob } from "./pipeline"

--- a/lib/github/pipeline.ts
+++ b/lib/github/pipeline.ts
@@ -1,0 +1,81 @@
+import { githubApi } from "./api"
+
+export interface WorkflowRun {
+    id: number
+    name: string
+    status: string
+    conclusion: string | null
+    html_url: string
+    head_branch: string
+    head_sha: string
+    created_at: string
+    updated_at: string
+}
+
+export interface WorkflowJob {
+    id: number
+    name: string
+    status: string
+    conclusion: string | null
+    html_url: string
+    steps: Array<{
+        name: string
+        status: string
+        conclusion: string | null
+        number: number
+    }>
+}
+
+/** List workflow runs for a branch */
+export async function listWorkflowRuns(
+    owner: string,
+    repo: string,
+    branch?: string
+): Promise<WorkflowRun[]> {
+    const branchQ = branch ? `&branch=${encodeURIComponent(branch)}` : ""
+    const data = await githubApi(`repos/${owner}/${repo}/actions/runs?${branchQ}`) as any
+    return (data?.workflow_runs ?? []) as WorkflowRun[]
+}
+
+/** Get a single workflow run by ID */
+export async function getWorkflowRun(
+    owner: string,
+    repo: string,
+    runId: number
+): Promise<WorkflowRun> {
+    const data = await githubApi(`repos/${owner}/${repo}/actions/runs/${runId}`)
+    return data as unknown as WorkflowRun
+}
+
+/** Get jobs for a workflow run */
+export async function getWorkflowJobs(
+    owner: string,
+    repo: string,
+    runId: number
+): Promise<WorkflowJob[]> {
+    const data = await githubApi(`repos/${owner}/${repo}/actions/runs/${runId}/jobs`) as any
+    return (data?.jobs ?? []) as WorkflowJob[]
+}
+
+/** Download the log for a specific job */
+export async function getJobLog(
+    owner: string,
+    repo: string,
+    jobId: number
+): Promise<string> {
+    const { token } = await import("./config").then(m => m.getGithubConfig())
+    const url = `https://api.github.com/repos/${owner}/${repo}/actions/jobs/${jobId}/logs`
+    const resp = await fetch(url, {
+        headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        redirect: "follow",
+    })
+    if (!resp.ok) {
+        const text = await resp.text()
+        throw new Error(`Failed to fetch job log for job ${jobId}: ${resp.status} ${text}`)
+    }
+    return resp.text()
+}

--- a/lib/github/pr.ts
+++ b/lib/github/pr.ts
@@ -1,0 +1,66 @@
+import { githubApi } from "./api"
+import { getRemote } from "../git"
+
+export interface PullRequest {
+    number: number
+    title: string
+    html_url: string
+    head: { ref: string }
+    base: { ref: string }
+    state: string
+    draft: boolean
+    user: { login: string }
+    merged_at: string | null
+}
+
+export interface CheckRun {
+    id: number
+    name: string
+    status: string
+    conclusion: string | null
+    html_url: string
+}
+
+/** Parse owner/repo from a GitHub SSH or HTTPS remote URL */
+export function parseRepo(remote: string): { owner: string; repo: string } {
+    // git@github.com:owner/repo.git  OR  https://github.com/owner/repo.git
+    const match = remote.match(/github\.com[:/]([^/]+)\/([^/.]+)(\.git)?/)
+    if (!match) throw new Error(`Could not parse GitHub repo from remote: ${remote}`)
+    return { owner: match[1], repo: match[2] }
+}
+
+export async function getRepoFromRemote(): Promise<{ owner: string; repo: string }> {
+    const remote = await getRemote()
+    return parseRepo(remote)
+}
+
+/** List open PRs for owner/repo, optionally filtered by branch */
+export async function listPullRequests(
+    owner: string,
+    repo: string,
+    branch?: string
+): Promise<PullRequest[]> {
+    const branchFilter = branch ? `&head=${owner}:${branch}` : ""
+    const data = await githubApi(`repos/${owner}/${repo}/pulls?state=open${branchFilter}`)
+    return data as unknown as PullRequest[]
+}
+
+/** Get a single PR by number */
+export async function getPullRequest(
+    owner: string,
+    repo: string,
+    prNumber: number
+): Promise<PullRequest> {
+    const data = await githubApi(`repos/${owner}/${repo}/pulls/${prNumber}`)
+    return data as unknown as PullRequest
+}
+
+/** Get check runs for a PR (via its head SHA) */
+export async function getCheckRuns(
+    owner: string,
+    repo: string,
+    ref: string
+): Promise<CheckRun[]> {
+    const data = await githubApi(`repos/${owner}/${repo}/commits/${ref}/check-runs`) as any
+    return (data?.check_runs ?? []) as CheckRun[]
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
     "git-lab-project": "dist/bin/git-lab-project.js",
     "git-lab-whoami": "dist/bin/git-lab-whoami.js",
     "git-lab": "dist/bin/git-lab.js",
+    "git-hub-pr-list": "dist/bin/git-hub-pr-list.js",
+    "git-hub-pr-checks": "dist/bin/git-hub-pr-checks.js",
+    "git-hub-run-log": "dist/bin/git-hub-run-log.js",
+    "git-hub-pr-fixup": "dist/bin/git-hub-pr-fixup.js",
     "gitj": "dist/bin/gitj.js",
     "gitj-install-skills": "dist/bin/gitj-install-skills.js"
   },


### PR DESCRIPTION
## Summary

Adds full GitHub integration to ya-git-jira, mirroring the existing GitLab module structure.

## New files

### lib/github/
| File | Purpose |
|------|---------|
| `config.ts` | Reads `github.token` + `github.user` from git config |
| `api.ts` | GitHub REST v3 wrapper with Bearer auth + pagination |
| `pr.ts` | PR list/view/check-runs, `parseRepo` from remote URL |
| `pipeline.ts` | Actions run list/view/jobs/log download |
| `index.ts` | Barrel export |

### bin/
| Command | Purpose |
|---------|---------|
| `git-hub-pr-list` | List open PRs for current repo (mirrors `git-lab-project-mr-list`) |
| `git-hub-pr-checks` | Show CI check status for PR on current branch |
| `git-hub-run-log` | Fetch failed Actions run log for current branch (mirrors `git-lab-project-pipeline-log`) |
| `git-hub-pr-fixup` | Show unresolved review comments on current PR (mirrors `git-lab-merge-active`) |

## Setup

Set in git config before use:
```bash
git config --global github.token <pat>
git config --global github.user <username>
```

## Note

`bun` is required to build (`bun run build.ts`). Not currently installed on this machine — needs `curl -fsSL https://bun.sh/install | bash`.

Resolves tasks:
- TASK #p0 ya-git-jira: Add lib/github/ module
- TASK #p0 ya-git-jira: Add bin/git-hub-pr-list.ts
- TASK #p0 ya-git-jira: Add bin/git-hub-pr-checks.ts
- TASK #p0 ya-git-jira: Add bin/git-hub-run-log.ts
- TASK #p0 ya-git-jira: Add bin/git-hub-pr-fixup.ts
